### PR TITLE
Remove `BuildersTestSupport` product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,6 @@ let package = Package(
 	],
 	products: [
 		.library(name: "Builders", targets: ["Builders"]),
-		.library(name: "BuildersTestSupport", targets: ["BuildersTestSupport"]),
 	],
 	targets: [
 		.target(name: "Builders"),


### PR DESCRIPTION
I think this was done by mistake.